### PR TITLE
Updated for more verbose output, identifying pass/fail KBs

### DIFF
--- a/controls/hotfixes.rb
+++ b/controls/hotfixes.rb
@@ -13,33 +13,23 @@ control 'WannaCry Vulnerability Check' do
 
   # List of known Knowledgebase IDs that include hotfixes for WannaCry
   # Do you have additional? Please submit a PR!
-  # Windows Server 2008:    KB4012212
-  # Windows Server 2012:    KB4012217 KB4015551 KB4019216
-  # Windows Server 2012 R2: KB4012216 KB4015550 KB4019215
-  # Windows Server 2016:    KB4013429 KB4019472 KB4015217 KB4015438 KB4016635
+  # Windows Server 2008:    KB4018466
+  # Windows Server 2008 R2: KB4012212 KB4012215 KB4015549 KB4019264
+  # Windows Server 2012:    KB4012214 KB4012217 KB4015551 KB4019216
+  # Windows Server 2012 R2: KB4012213 KB4012216 KB4015550 KB4019215 KB4012219 KB4015553 KB4015554
+  # Windows Server 2016:    KB4013429 KB4019472 KB4015217 KB4015438 KB4016635 KB4016871
 
-  script = <<-EOH
-  $hotfixes = "KB4012212", "KB4012217", "KB4015551", "KB4019216", "KB4012216", "KB4015550", "KB4019215", "KB4013429", "KB4019472", "KB4015217", "KB4015438", "KB4016635"
+  hotfixes = %w{ KB4012212 KB4012213 KB4012214 KB4012215 KB4012216 KB4012217 KB4012219 KB4013429 KB4015217 KB4015438 KB4015549 KB4015550 KB4015551 KB4015553 KB4015554 KB4016635 KB4016871 KB4018466 KB4019215 KB4019216 KB4019264 KB4019472 }
 
-  $computer = $ENV:COMPUTERNAME
-
-  $hotfix = Get-HotFix -ComputerName $computer |
-      Where-Object {$hotfixes -contains $_.HotfixID} |
-      Select-Object -property "HotFixID"
-
-  if($hotfix) {
-      Write-Output "System OK. $computer has hotfix $hotfix installed."
-      exit 0
-  } else {
-      Write-Output "***************************************************"
-      Write-Output "* You are vulnerable to the WannaCry Exploit.     *"
-      Write-Output "* Please run Windows Update to patch this system. *"
-      Write-Output "***************************************************"
-      exit 1
-  }
-  EOH
-
-  describe powershell(script) do
-    its('exit_status') { should eq 0 }
+  describe.one do
+    hotfixes.each do |hotfix|
+      filter = "HotFixID = '" + hotfix + "'"
+      describe wmi({
+        class: 'win32_quickfixengineering',
+        filter: filter,
+      }) do
+        its( 'InstalledOn' ) { should_not eq nil }
+      end
+    end
   end
 end


### PR DESCRIPTION
Rewrote the control to show the KBs tested on failure and to print the
KB that was found installed on success. Rolled up #2 from @jdgoins.

Signed-off-by: Matt Ray <matthewhray@gmail.com>